### PR TITLE
Outputs look good.

### DIFF
--- a/cloudformation/cloudformation-kms.template.js
+++ b/cloudformation/cloudformation-kms.template.js
@@ -2,6 +2,7 @@ var ref = require('cloudfriend').ref;
 var cif = require('cloudfriend').if;
 var join = require('cloudfriend').join;
 var equals = require('cloudfriend').equals;
+var getAtt = require('cloudfriend').getAtt;
 
 module.exports = {
   AWSTemplateFormatVersion: '2010-09-09',

--- a/cloudformation/cloudformation-kms.template.js
+++ b/cloudformation/cloudformation-kms.template.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   Outputs: {
     Key: {
-      Value: cif('CreateKey', ref('Key'), ref('LegacyKeyArn')),
+      Value: cif('CreateKey', getAtt('Key', 'Arn'), ref('LegacyKeyArn')),
       Export: {
         Name: ref('AWS::StackName')
       }
@@ -55,4 +55,3 @@ module.exports = {
     CreateKey: equals(ref('LegacyKeyArn'), '')
   }
 };
-


### PR DESCRIPTION
Fixes https://github.com/mapbox/cloudformation-kms/issues/2 

Tested @xrwang's fixes in https://github.com/mapbox/cloudformation-kms/commits/secret yesterday by creating a staging stack in `ap-northeast-2`. I tested to see how it worked with/without the `LegacyArn` parameter. In both cases, the output was `arn:aws:kms:ap-northeast-2:<account-id>:key/<key-sha>`

cc/ @xrwang @jakepruitt @rclark
