### PR TITLE
Update node version, cloudfriend namespace

### DIFF
--- a/cloudformation/cloudformation-kms.template.js
+++ b/cloudformation/cloudformation-kms.template.js
@@ -1,8 +1,8 @@
-var ref = require('cloudfriend').ref;
-var cif = require('cloudfriend').if;
-var join = require('cloudfriend').join;
-var equals = require('cloudfriend').equals;
-var getAtt = require('cloudfriend').getAtt;
+var ref = require('@mapbox/cloudfriend').ref;
+var cif = require('@mapbox/cloudfriend').if;
+var join = require('@mapbox/cloudfriend').join;
+var equals = require('@mapbox/cloudfriend').equals;
+var getAtt = require('@mapbox/cloudfriend').getAtt;
 
 module.exports = {
   AWSTemplateFormatVersion: '2010-09-09',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "homepage": "https://github.com/mapbox/cloudformation-kms",
   "dependencies": {
-    "cloudfriend": "^2.0.0"
+    "@mapbox/cloudfriend": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudformation-kms",
-  "version": "1.0.0",
-  "description": "KMS key for encrypting CloudFormation parameters",
+  "version": "1.1.0",
+  "description": "create KMS key for encrypting CloudFormation parameters",
   "repository": {
     "type": "git",
     "url": "git://github.com/mapbox/cloudformation-kms.git"
@@ -12,10 +12,7 @@
     "url": "https://github.com/mapbox/cloudformation-kms/issues"
   },
   "homepage": "https://github.com/mapbox/cloudformation-kms",
-  "engines": {
-    "node": "4.4.2"
-  },
   "dependencies": {
-    "cloudfriend": "^1.5.0"
+    "cloudfriend": "^2.0.0"
   }
 }


### PR DESCRIPTION
Resolving requirements in https://github.com/mapbox/cloudformation-kms/issues/5, removes hard requirement for Node 4 engine from package.json and updates `cloudfriend` to its `@mapbox/cloudfriend` namespace and latest version.

Opted for minor version bump.

/cc @mapbox/assembly-line 